### PR TITLE
Fix test_dispatcher errors in Visual Studio.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,9 +99,9 @@ add_executable(test_dispatcher EXCLUDE_FROM_ALL
     ${TEST_DISPATCHER_SOURCES}
     ${TEST_DISPATCHER_ARCH_GEN_SOURCES}
 )
-target_link_libraries(test_dispatcher pthread)
 
 if(NOT MSVC)
+    target_link_libraries(test_dispatcher pthread)
     set_target_properties(test_dispatcher PROPERTIES COMPILE_FLAGS "-pthread -std=c++11 -g2 -Wall")
 endif()
 

--- a/test/main_dispatcher.cc
+++ b/test/main_dispatcher.cc
@@ -8,6 +8,7 @@
 #include "tests/dispatcher.h"
 #include <algorithm>
 #include <iostream>
+#include <string>
 #include <cstdlib>
 
 static simdpp::Arch g_supported_arch;


### PR DESCRIPTION
Some errors were left when compiling test_dispatcher.
