### PR TITLE
Unaligned store

### DIFF
--- a/simdpp/CMakeLists.txt
+++ b/simdpp/CMakeLists.txt
@@ -93,6 +93,7 @@ set(HEADERS
     core/store_packed2.h
     core/store_packed3.h
     core/store_packed4.h
+    core/store_u.h
     core/stream.h
     core/to_float32.h
     core/to_float64.h

--- a/simdpp/core/store_u.h
+++ b/simdpp/core/store_u.h
@@ -1,0 +1,50 @@
+/*  Copyright (C) 2015
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_SIMDPP_CORE_STORE_U_H
+#define LIBSIMDPP_SIMDPP_CORE_STORE_U_H
+
+#ifndef LIBSIMDPP_SIMD_H
+    #error "This file must be included through simd.h"
+#endif
+
+#include <simdpp/types.h>
+#include <simdpp/detail/insn/store_u.h>
+
+namespace simdpp {
+#ifndef SIMDPP_DOXYGEN
+namespace SIMDPP_ARCH_NAMESPACE {
+#endif
+
+/** Stores a 128-bit or 256-bit integer to an unaligned memory location.
+
+    @par 128-bit version:
+
+    @code
+    *(p) = a[0..127]
+    @endcode
+
+    @par 256-bit version:
+
+    @code
+    *(p) = a[0..255]
+    @endcode
+*/
+template<unsigned N, class V> SIMDPP_INL
+void store_u(void* p, const any_vec<N,V>& a)
+{
+    static_assert(!is_mask<V>::value, "Masks can not be stored"); // FIXME: automatically convert
+    detail::insn::i_store_u(reinterpret_cast<char*>(p), a.wrapped().eval());
+}
+
+#ifndef SIMDPP_DOXYGEN
+} // namespace SIMDPP_ARCH_NAMESPACE
+#endif
+} // namespace simdpp
+
+#endif
+

--- a/simdpp/detail/insn/store_u.h
+++ b/simdpp/detail/insn/store_u.h
@@ -1,0 +1,170 @@
+/*  Copyright (C) 2015
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_SIMDPP_DETAIL_INSN_STORE_U_H
+#define LIBSIMDPP_SIMDPP_DETAIL_INSN_STORE_U_H
+
+#ifndef LIBSIMDPP_SIMD_H
+    #error "This file must be included through simd.h"
+#endif
+
+#include <simdpp/types.h>
+#include <simdpp/detail/null/memory.h>
+#include <simdpp/detail/align.h>
+
+namespace simdpp {
+#ifndef SIMDPP_DOXYGEN
+namespace SIMDPP_ARCH_NAMESPACE {
+#endif
+namespace detail {
+namespace insn {
+
+SIMDPP_INL void i_store_u(char* p, const uint8<16>& a)
+{
+#if SIMDPP_USE_NULL
+    detail::null::store(p, a);
+#elif SIMDPP_USE_SSE2
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(p), a);
+#elif SIMDPP_USE_NEON
+    vst1q_u64(reinterpret_cast<uint64_t*>(p), vreinterpretq_u64_u8(a));
+#elif SIMDPP_USE_ALTIVEC
+    vec_stl((__vector uint8_t)a, 0, reinterpret_cast<uint8_t*>(p));
+#endif
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint16<8>& a)
+{
+    i_store_u(p, uint8<16>(a));
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint32<4>& a)
+{
+    i_store_u(p, uint8<16>(a));
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint64<2>& a)
+{
+    i_store_u(p, uint8<16>(a));
+}
+
+SIMDPP_INL void i_store_u(char* p, const float32x4& a)
+{
+    float* q = reinterpret_cast<float*>(p);
+#if SIMDPP_USE_NULL || SIMDPP_USE_NEON_NO_FLT_SP
+    detail::null::store(q, a);
+#elif SIMDPP_USE_SSE2
+    _mm_storeu_ps(q, a);
+#elif SIMDPP_USE_NEON
+    vst1q_f32(q, a);
+#elif SIMDPP_USE_ALTIVEC
+    vec_stl((__vector float)a, 0, q);
+#endif
+}
+
+SIMDPP_INL void i_store_u(char* p, const float64x2& a)
+{
+    double* q = reinterpret_cast<double*>(p);
+#if SIMDPP_USE_NULL || SIMDPP_USE_NEON32 || SIMDPP_USE_ALTIVEC
+    detail::null::store(q, a);
+#elif SIMDPP_USE_SSE2
+    _mm_storeu_pd(q, a);
+#elif SIMDPP_USE_NEON64
+    vst1q_f64(q, a);
+#endif
+}
+
+
+#if SIMDPP_USE_AVX2
+SIMDPP_INL void i_store_u(char* p, const uint8<32>& a)
+{
+    _mm256_storeu_si256(reinterpret_cast<__m256i*>(p), a);
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint16<16>& a)
+{
+    i_store_u(p, uint8<32>(a));
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint32<8>& a)
+{
+    i_store_u(p, uint8<32>(a));
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint64<4>& a)
+{
+    i_store_u(p, uint8<32>(a));
+}
+#endif
+
+#if SIMDPP_USE_AVX
+SIMDPP_INL void i_store_u(char* p, const float32x8& a)
+{
+    _mm256_storeu_ps(reinterpret_cast<float*>(p), a);
+}
+
+SIMDPP_INL void i_store_u(char* p, const float64x4& a)
+{
+    _mm256_storeu_pd(reinterpret_cast<double*>(p), a);
+}
+#endif
+
+#if SIMDPP_USE_AVX512
+SIMDPP_INL void i_store_u(char* p, const uint32<16>& a)
+{
+    _mm512_storeu_si512(reinterpret_cast<__m512i*>(p), a);
+}
+
+SIMDPP_INL void i_store_u(char* p, const uint64<8>& a)
+{
+    _mm512_storeu_si512(reinterpret_cast<__m512i*>(p), a);
+}
+
+SIMDPP_INL void i_store_u(char* p, const float32<16>& a)
+{
+    _mm512_storeu_ps(p, a);
+}
+
+SIMDPP_INL void i_store_u(char* p, const float64<8>& a)
+{
+    _mm512_storeu_pd(p, a);
+}
+#endif
+
+template<class V> SIMDPP_INL
+void v_store_u(char* p, const V& a)
+{
+    unsigned veclen = sizeof(typename V::base_vector_type);
+
+    for (unsigned i = 0; i < V::vec_length; ++i) {
+        i_store_u(p, a.vec(i));
+        p += veclen;
+    }
+}
+
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const uint8<N>& a) { v_store_u(p, a); }
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const uint16<N>& a) { v_store_u(p, a); }
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const uint32<N>& a) { v_store_u(p, a); }
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const uint64<N>& a) { v_store_u(p, a); }
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const float32<N>& a){ v_store_u(p, a); }
+template<unsigned N> SIMDPP_INL
+void i_store_u(char* p, const float64<N>& a){ v_store_u(p, a); }
+
+
+} // namespace insn
+} // namespace detail
+#ifndef SIMDPP_DOXYGEN
+} // namespace SIMDPP_ARCH_NAMESPACE
+#endif
+} // namespace simdpp
+
+#endif
+

--- a/simdpp/detail/insn/store_u.h
+++ b/simdpp/detail/insn/store_u.h
@@ -31,7 +31,7 @@ SIMDPP_INL void i_store_u(char* p, const uint8<16>& a)
 #elif SIMDPP_USE_SSE2
     _mm_storeu_si128(reinterpret_cast<__m128i*>(p), a);
 #elif SIMDPP_USE_NEON
-    vst1q_u64(reinterpret_cast<uint64_t*>(p), vreinterpretq_u64_u8(a));
+    vst1q_u8(reinterpret_cast<uint8_t*>(p), a);
 #elif SIMDPP_USE_ALTIVEC
     // From https://web.archive.org/web/20110305043420/http://developer.apple.com/hardwaredrivers/ve/alignment.html
     uint8_t* q = reinterpret_cast<uint8_t*>(p);
@@ -51,17 +51,29 @@ SIMDPP_INL void i_store_u(char* p, const uint8<16>& a)
 
 SIMDPP_INL void i_store_u(char* p, const uint16<8>& a)
 {
+#if SIMDPP_USE_NEON
+    vst1q_u16(reinterpret_cast<uint16_t*>(p), a);
+#else
     i_store_u(p, uint8<16>(a));
+#endif
 }
 
 SIMDPP_INL void i_store_u(char* p, const uint32<4>& a)
 {
+#if SIMDPP_USE_NEON
+    vst1q_u32(reinterpret_cast<uint32_t*>(p), a);
+#else
     i_store_u(p, uint8<16>(a));
+#endif
 }
 
 SIMDPP_INL void i_store_u(char* p, const uint64<2>& a)
 {
+#if SIMDPP_USE_NEON
+    vst1q_u64(reinterpret_cast<uint64_t*>(p), a);
+#else
     i_store_u(p, uint8<16>(a));
+#endif
 }
 
 SIMDPP_INL void i_store_u(char* p, const float32x4& a)

--- a/simdpp/simd.h
+++ b/simdpp/simd.h
@@ -103,6 +103,7 @@
 #include <simdpp/core/store_packed2.h>
 #include <simdpp/core/store_packed3.h>
 #include <simdpp/core/store_packed4.h>
+#include <simdpp/core/store_u.h>
 #include <simdpp/core/stream.h>
 #include <simdpp/core/to_float32.h>
 #include <simdpp/core/to_float64.h>

--- a/test/insn/memory_store.cc
+++ b/test/insn/memory_store.cc
@@ -38,6 +38,18 @@ void test_store_helper(TestSuite& tc, const V* sv)
 
     for (unsigned i = 0; i < vnum; i++) {
         rzero(rv);
+        store_u(rdata+i*V::length, sv[0]);
+        TEST_ARRAY_PUSH(tc, V, rv);
+    }
+
+    for (unsigned i = 0; i < (vnum-1)*V::length; i++) {
+        rzero(rv);
+        store_u(rdata+i, sv[0]);
+        TEST_ARRAY_PUSH(tc, V, rv);
+    }
+
+    for (unsigned i = 0; i < vnum; i++) {
+        rzero(rv);
         stream(rdata+i*V::length, sv[0]);
         TEST_ARRAY_PUSH(tc, V, rv);
     }


### PR DESCRIPTION
There does not appear to be a function for unaligned stores. There's simdpp::load for aligned loads and simdpp::load_u for unaligned loads, but the only store function is simdpp::store.

This pull-request adds simdpp::store_u for unaligned stores.

store_u generates the correct instruction for SSE2, and 'make check' works on GCC on x86-64 and ARM without NEON. Beyond that, it is untested (neon and altivec code is just a guess based on the existing code for simdpp::store).