### PR TITLE
Missing include for operator/

### DIFF
--- a/simdpp/simd.h
+++ b/simdpp/simd.h
@@ -184,6 +184,7 @@
 #include <simdpp/operators/cmp_le.h>
 #include <simdpp/operators/cmp_lt.h>
 #include <simdpp/operators/f_add.h>
+#include <simdpp/operators/f_div.h>
 #include <simdpp/operators/f_mul.h>
 #include <simdpp/operators/f_sub.h>
 #include <simdpp/operators/i_add.h>


### PR DESCRIPTION
#include <simdpp/operators/f_div.h> was not present with other #include <simdpp/operators/f_*.h>.