### PR TITLE
Fix signed store and similar operations

### DIFF
--- a/simdpp/detail/insn/store.h
+++ b/simdpp/detail/insn/store.h
@@ -174,10 +174,10 @@ SIMDPP_INL void i_store(char* p, const float64<8>& a)
 // -----------------------------------------------------------------------------
 
 template<class V> SIMDPP_INL
-void i_store(char* p, const V& a)
+void i_store(char* p, const V& ca)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
-
+    typename detail::remove_sign<V>::type a = ca;
     p = detail::assume_aligned(p, veclen);
     for (unsigned i = 0; i < V::vec_length; ++i) {
         i_store(p, a.vec(i));
@@ -191,4 +191,3 @@ void i_store(char* p, const V& a)
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/store_first.h
+++ b/simdpp/detail/insn/store_first.h
@@ -244,10 +244,11 @@ SIMDPP_INL void i_store_first(char* p, const float64<8>& a, unsigned n)
 // -----------------------------------------------------------------------------
 
 template<class V> SIMDPP_INL
-void i_store_first(char* p, const V& a, unsigned n)
+void i_store_first(char* p, const V& ca, unsigned n)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
 
+    typename detail::remove_sign<V>::type a = ca;
     p = detail::assume_aligned(p, veclen);
 
     unsigned n_full_vec = n / V::base_vector_type::length;
@@ -270,4 +271,3 @@ void i_store_first(char* p, const V& a, unsigned n)
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/store_last.h
+++ b/simdpp/detail/insn/store_last.h
@@ -257,10 +257,11 @@ SIMDPP_INL void i_store_last(char* p, const float64<8>& a, unsigned n)
 // -----------------------------------------------------------------------------
 
 template<class V> SIMDPP_INL
-void i_store_last(char* p, const V& a, unsigned n)
+void i_store_last(char* p, const V& ca, unsigned n)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
 
+    typename detail::remove_sign<V>::type a = ca;
     p = detail::assume_aligned(p, veclen);
     unsigned el_to_skip = V::length - n;
 
@@ -288,4 +289,3 @@ void i_store_last(char* p, const V& a, unsigned n)
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/store_packed2.h
+++ b/simdpp/detail/insn/store_packed2.h
@@ -238,7 +238,7 @@ template<class V> SIMDPP_INL
 void i_store_packed2(char* p, const V& ca, const V& cb)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
-    V a = ca, b = cb;
+    typename detail::remove_sign<V>::type a = ca, b = cb;
 
     p = detail::assume_aligned(p, veclen);
     for (unsigned i = 0; i < V::vec_length; ++i) {
@@ -253,4 +253,3 @@ void i_store_packed2(char* p, const V& ca, const V& cb)
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/store_packed3.h
+++ b/simdpp/detail/insn/store_packed3.h
@@ -271,7 +271,7 @@ void v512_store_pack3(char* p, const V& ca, const V& cb, const V& cc)
 template<class V> SIMDPP_INL
 void i_store_packed3(char* p, const V& ca, const V& cb, const V& cc)
 {
-    V a = ca, b = cb, c = cc;
+    typename detail::remove_sign<V>::type a = ca, b = cb, c = cc;
     unsigned veclen = sizeof(typename V::base_vector_type);
 
     p = detail::assume_aligned(p, veclen);
@@ -287,4 +287,3 @@ void i_store_packed3(char* p, const V& ca, const V& cb, const V& cc)
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/store_packed4.h
+++ b/simdpp/detail/insn/store_packed4.h
@@ -274,7 +274,7 @@ template<class V> SIMDPP_INL
 void i_store_packed4(char* p, const V& ca, const V& cb, const V& cc, const V& dd)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
-    V a = ca, b = cb, c = cc, d = dd;
+    typename detail::remove_sign<V>::type a = ca, b = cb, c = cc, d = dd;
 
     p = detail::assume_aligned(p, veclen);
     for (unsigned i = 0; i < V::vec_length; ++i) {
@@ -289,4 +289,3 @@ void i_store_packed4(char* p, const V& ca, const V& cb, const V& cc, const V& dd
 } // namespace simdpp
 
 #endif
-

--- a/simdpp/detail/insn/stream.h
+++ b/simdpp/detail/insn/stream.h
@@ -173,10 +173,10 @@ SIMDPP_INL void i_stream(char* p, const float64<8>& a)
 // -----------------------------------------------------------------------------
 
 template<class V> SIMDPP_INL
-void i_stream(char* p, const V& a)
+void i_stream(char* p, const V& ca)
 {
     unsigned veclen = sizeof(typename V::base_vector_type);
-
+    typename detail::remove_sign<V>::type a = ca;
     p = detail::assume_aligned(p, veclen);
     for (unsigned i = 0; i < V::vec_length; ++i) {
         i_stream(p, a.vec(i));
@@ -190,4 +190,3 @@ void i_stream(char* p, const V& a)
 } // namespace simdpp
 
 #endif
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,7 +109,7 @@ if(MSVC)
         set_target_properties(test1 PROPERTIES COMPILE_FLAGS "/Gv")
     endif()
 else()
-    set_target_properties(test1 PROPERTIES COMPILE_FLAGS "-std=c++11 -O1 -g1 -Wall -Wextra")
+    set_target_properties(test1 PROPERTIES COMPILE_FLAGS "-std=c++11 -O0 -g2 -Wall -Wextra")
 endif()
 
 add_test(s_test1 test1)
@@ -191,4 +191,3 @@ endif()
 
 add_test(s_test_expr1 test_expr)
 add_dependencies(check test_expr)
-

--- a/test/insn/memory_load.cc
+++ b/test/insn/memory_load.cc
@@ -88,6 +88,12 @@ void test_memory_load_n(TestSuite& tc)
     test_load_helper<uint16<B/2>, vnum>(tc, v.u16);
     test_load_helper<uint32<B/4>, vnum>(tc, v.u32);
     test_load_helper<uint64<B/8>, vnum>(tc, v.u64);
+
+    test_load_helper<int8<B>, vnum>(tc, v.i8);
+    test_load_helper<int16<B/2>, vnum>(tc, v.i16);
+    test_load_helper<int32<B/4>, vnum>(tc, v.i32);
+    test_load_helper<int64<B/8>, vnum>(tc, v.i64);
+
     test_load_helper<float32<B/4>, vnum>(tc, v.f32);
     test_load_helper<float64<B/8>, vnum>(tc, v.f64);
 }

--- a/test/insn/memory_store.cc
+++ b/test/insn/memory_store.cc
@@ -119,11 +119,19 @@ void test_memory_store_n(TestSuite& tc)
     test_store_helper<uint16<B/2>, vnum>(tc, v.u16);
     test_store_helper<uint32<B/4>, vnum>(tc, v.u32);
     test_store_helper<uint64<B/8>, vnum>(tc, v.u64);
+
+    test_store_helper<int8<B>, vnum>(tc, v.i8);
+    test_store_helper<int16<B/2>, vnum>(tc, v.i16);
+    test_store_helper<int32<B/4>, vnum>(tc, v.i32);
+    test_store_helper<int64<B/8>, vnum>(tc, v.i64);
+
     test_store_helper<float32<B/4>, vnum>(tc, v.f32);
     test_store_helper<float64<B/8>, vnum>(tc, v.f64);
 
     test_store_masked<uint32<B/4>>(tc, v.u32);
     test_store_masked<uint64<B/8>>(tc, v.u64);
+    test_store_masked<int32<B/4>>(tc, v.i32);
+    test_store_masked<int64<B/8>>(tc, v.i64);
     test_store_masked<float32<B/4>>(tc, v.f32);
     test_store_masked<float64<B/8>>(tc, v.f64);
 }


### PR DESCRIPTION
Testing on OSX 10.10 with Apple Clang 7.0.2, I found that doing a store with an int16<N> (or any signed integer) would silently fail with any optimizations enabled. With no optimizations, the i_store template method in the backend would recurse infinitely until stack overflow. This appeared to be because the templated i_store would always match when V is signed, as no signed implementations occur and the value is not converted to unsigned.

Curiously, store_u works because the front-end calls the templated v_store_u, and that calls i_store_u. Without the template matching, this allows implicit type conversion to change e.g. int16 to uint16. Also the load operations appear to explicitly use unsigned values when calling the backend, then convert to signed if necessary.

This pull request:
* Add signed store and load tests
* Convert signed to unsigned in store, store_first, store_last, store_packed*, stream
* Change the test CMakeLists to do no optimizations. (Optimizations can silently hide these test failures.)

Note that if you add only the CMakeLists.txt change and the updated tests to exercise signed store and signed load (signed load worked originally, but more tests can't hurt), then this is the test output:

```
test 1
    Start 1: s_test1

1: Test command: /Users/joshblake/projects/libsimdpp/build/test/test1
1: Test timeout computed to be: 9.99988e+06
1/9 Test #1: s_test1 ..........................***Exception: SegFault  0.98 sec
```
Tests 2-9 still passed.

The rest of this PR fixes this test failure for store as well as similar issues in other memory ops.

Since there were several ways to implement this (and a few techniques used across the backend) I chose the one most similar to existing techniques and least invasive. Let me know if you have any concerns or feedback about this approach.