### PR TITLE
Update raw cpuid to be more cross-platform friendly:

### DIFF
--- a/simdpp/dispatch/get_arch_raw_cpuid.h
+++ b/simdpp/dispatch/get_arch_raw_cpuid.h
@@ -8,7 +8,16 @@
 #ifndef LIBSIMDPP_DISPATCH_GET_ARCH_RAW_CPUID_H
 #define LIBSIMDPP_DISPATCH_GET_ARCH_RAW_CPUID_H
 
-#if (__i386__ || __amd64__) && (__clang__ || __GNUC__ || __INTEL_COMPILER || _MSC_VER)
+#if __i386__ || _M_IX86
+#  define SIMDPP_CPU_32 1
+#  define SIMDPP_CPU_64 0
+#endif
+#if __amd64__ || __x86_64__ || _M_X64
+#  define SIMDPP_CPU_32 0
+#  define SIMDPP_CPU_64 1
+#endif
+
+#if (SIMDPP_CPU_32 || SIMDPP_CPU_64) && (__clang__ || __GNUC__ || __INTEL_COMPILER || _MSC_VER)
 #define SIMDPP_HAS_GET_ARCH_RAW_CPUID 1
 
 #include <simdpp/dispatch/arch.h>
@@ -27,7 +36,7 @@ inline void get_cpuid(unsigned level, unsigned subleaf, unsigned* eax, unsigned*
 #if __clang__ || __INTEL_COMPILER
     // Older versions of clang don't support subleafs, which leads to inability
     // to detect AVX2 for example. On ICC there's no proper cpuid intrinsic.
-#if __i386__
+#if SIMDPP_CPU_32
     __asm("cpuid" : "=a"(*eax), "=b" (*ebx), "=c"(*ecx), "=d"(*edx) \
                   : "0"(level), "2"(subleaf));
 #else
@@ -127,6 +136,6 @@ inline Arch get_arch_raw_cpuid()
 
 } // namespace simdpp
 
-#endif // #if (__i386__ || __amd64__) && ...
+#endif // #if (SIMDPP_CPU_32 || SIMDPP_CPU_64) && ...
 
 #endif


### PR DESCRIPTION
Adds Windows MSVC pre-processor macros for x86 and x64

Before, compilation fails on VS2013 and VS2015 since it doesn't know about __i386__ or __amd64__, causing SIMDPP_HAS_GET_ARCH_RAW_CPUID to not be defined, which lets the dynamic dispatcher example logic to fall through to "Unsupported platform" in:

```
#if SIMDPP_HAS_GET_ARCH_RAW_CPUID
#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_raw_cpuid()
#elif SIMDPP_HAS_GET_ARCH_GCC_BUILTIN_CPU_SUPPORTS
#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_gcc_builtin_cpu_supports()
#elif SIMDPP_HAS_GET_ARCH_LINUX_CPUINFO
#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_linux_cpuinfo()
#else
#error "Unsupported platform"
#endif
```