### PR TITLE
Allow template functions whose type cannot be deduced from arguments

### DIFF
--- a/simdpp/dispatch/collect_macros_generated.h
+++ b/simdpp/dispatch/collect_macros_generated.h
@@ -157,7 +157,7 @@
 
     #define SIMDPP_DISPATCH_1_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_1_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_1_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[1-1] = ::simdpp::SIMDPP_DISPATCH_1_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -303,7 +303,7 @@
 
     #define SIMDPP_DISPATCH_2_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_2_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_2_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[2-1] = ::simdpp::SIMDPP_DISPATCH_2_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -449,7 +449,7 @@
 
     #define SIMDPP_DISPATCH_3_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_3_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_3_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[3-1] = ::simdpp::SIMDPP_DISPATCH_3_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -595,7 +595,7 @@
 
     #define SIMDPP_DISPATCH_4_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_4_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_4_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[4-1] = ::simdpp::SIMDPP_DISPATCH_4_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -741,7 +741,7 @@
 
     #define SIMDPP_DISPATCH_5_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_5_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_5_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[5-1] = ::simdpp::SIMDPP_DISPATCH_5_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -887,7 +887,7 @@
 
     #define SIMDPP_DISPATCH_6_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_6_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_6_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[6-1] = ::simdpp::SIMDPP_DISPATCH_6_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1033,7 +1033,7 @@
 
     #define SIMDPP_DISPATCH_7_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_7_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_7_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[7-1] = ::simdpp::SIMDPP_DISPATCH_7_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1179,7 +1179,7 @@
 
     #define SIMDPP_DISPATCH_8_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_8_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_8_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[8-1] = ::simdpp::SIMDPP_DISPATCH_8_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1325,7 +1325,7 @@
 
     #define SIMDPP_DISPATCH_9_FN_REGISTER(ARRAY,NAME,FUN_TYPE)                \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_9_NAMESPACE::NAME;            \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_9_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);            \
             ARRAY[9-1] = ::simdpp::SIMDPP_DISPATCH_9_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1471,7 +1471,7 @@
 
     #define SIMDPP_DISPATCH_10_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_10_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_10_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[10-1] = ::simdpp::SIMDPP_DISPATCH_10_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1617,7 +1617,7 @@
 
     #define SIMDPP_DISPATCH_11_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_11_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_11_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[11-1] = ::simdpp::SIMDPP_DISPATCH_11_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1763,7 +1763,7 @@
 
     #define SIMDPP_DISPATCH_12_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_12_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_12_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[12-1] = ::simdpp::SIMDPP_DISPATCH_12_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -1909,7 +1909,7 @@
 
     #define SIMDPP_DISPATCH_13_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_13_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_13_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[13-1] = ::simdpp::SIMDPP_DISPATCH_13_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -2055,7 +2055,7 @@
 
     #define SIMDPP_DISPATCH_14_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_14_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_14_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[14-1] = ::simdpp::SIMDPP_DISPATCH_14_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 
@@ -2201,7 +2201,7 @@
 
     #define SIMDPP_DISPATCH_15_FN_REGISTER(ARRAY,NAME,FUN_TYPE)               \
         {   /* the following will fail if the overload is not available */    \
-            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_15_NAMESPACE::NAME;           \
+            FUN_TYPE fun_ptr = &SIMDPP_DISPATCH_15_NAMESPACE::SIMDPP_PP_REMOVE_PARENS(NAME);           \
             ARRAY[15-1] = ::simdpp::SIMDPP_DISPATCH_15_NAMESPACE::detail::create_fn_version(fun_ptr);\
         }
 

--- a/simdpp/dispatch/make_dispatcher.h
+++ b/simdpp/dispatch/make_dispatcher.h
@@ -146,7 +146,7 @@
 #undef SIMDPP_DETAIL_FORWARD
 #undef SIMDPP_DETAIL_ARGS
 */
-#define SIMDPP_DETAIL_MAKE_DISPATCHER_IMPL(TEMPLATE_PREFIX, R, NAME, ARGS)             \
+#define SIMDPP_DETAIL_MAKE_DISPATCHER_IMPL(TEMPLATE_PREFIX, R, NAME, ARGS, TEMPLATE_SUFFIX)             \
                                                                                 \
 SIMDPP_DISPATCH_DECLARE_FUNCTIONS(                                              \
     (SIMDPP_PP_REMOVE_PARENS(TEMPLATE_PREFIX)                                   \
@@ -159,7 +159,7 @@ SIMDPP_PP_REMOVE_PARENS(R) NAME(SIMDPP_DETAIL_ARGS(ARGS))                       
     static FunPtr selected = nullptr;                                           \
     if (selected == nullptr) {                                                  \
         ::simdpp::detail::FnVersion versions[SIMDPP_DISPATCH_MAX_ARCHS] = {};   \
-        SIMDPP_DISPATCH_COLLECT_FUNCTIONS(versions, NAME, FunPtr)               \
+        SIMDPP_DISPATCH_COLLECT_FUNCTIONS(versions, (NAME SIMDPP_PP_REMOVE_PARENS(TEMPLATE_SUFFIX)), FunPtr)               \
         ::simdpp::detail::FnVersion version =                                   \
             ::simdpp::detail::select_version_any(versions,                      \
                 SIMDPP_DISPATCH_MAX_ARCHS, SIMDPP_USER_ARCH_INFO);              \
@@ -177,18 +177,27 @@ SIMDPP_PP_REMOVE_PARENS(R) NAME(SIMDPP_DETAIL_ARGS(ARGS))                       
         (),                                                                     \
         (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(DESC)),                         \
         SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(DESC)), \
-        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC)))))
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC)))), \
+        ())
 
 #define SIMDPP_DETAIL_MAKE_DISPATCHER4(DESC)                                    \
     SIMDPP_DETAIL_MAKE_DISPATCHER_IMPL(                                         \
         (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(DESC)),                         \
         (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(DESC))), \
         SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC))), \
-        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC))))))
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC))))), \
+        ())
+#define SIMDPP_DETAIL_MAKE_DISPATCHER5(DESC)                                  \
+  SIMDPP_DETAIL_MAKE_DISPATCHER_IMPL(                                         \
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(DESC)),                         \
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(DESC))), \
+        SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC))), \
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC))))), \
+        (SIMDPP_DETAIL_EXTRACT_PARENS_IGNORE_REST(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(SIMDPP_DETAIL_IGNORE_PARENS(DESC)))))))
 
 
-#define SIMDPP_DETAIL_MAKE_DISPATCHER5(DESC) SIMDPP_ERROR_INCORRECT_NUMBER_OF_ARGUMENTS
 #define SIMDPP_DETAIL_MAKE_DISPATCHER6(DESC) SIMDPP_ERROR_INCORRECT_NUMBER_OF_ARGUMENTS
+#define SIMDPP_DETAIL_MAKE_DISPATCHER7(DESC) SIMDPP_ERROR_INCORRECT_NUMBER_OF_ARGUMENTS
 
 /** Builds a dispatcher for a specific non-member function. The same macro is
     used for functions with or without return value, with different parameter


### PR DESCRIPTION
Not sure the construction is 100% sound, nor sure that it works with the other tests, but this works for clang on Xcode, at least to compile the code.
