### PR TITLE
Possible fix for GCC 7.3.1 c++17 compilation error

### DIFF
--- a/simdpp/detail/insn/cmp_neq.h
+++ b/simdpp/detail/insn/cmp_neq.h
@@ -192,7 +192,7 @@ mask_int64x2 i_cmp_neq(const uint64x2& a, const uint64x2& b)
     return bit_not(cmp_eq(a, b));
 #elif SIMDPP_USE_SSE2
     uint64x2 r32, r32s;
-    r32 = (uint32x4)cmp_eq(uint32x4(a), uint32x4(b));
+    r32 = cmp_eq(uint32x4(a), uint32x4(b));
     // swap the 32-bit halves
     r32s = bit_or(shift_l<32>(r32), shift_r<32>(r32));
     // combine the results. Each 32-bit half is ORed with the neighbouring pair
@@ -381,4 +381,3 @@ typename V::mask_vector_type i_cmp_neq(const V& a, const V& b)
 } // namespace simdpp
 
 #endif
-


### PR DESCRIPTION
Hello and thank you for creating and maintaining this great library.

I haven't had any problems using the library with c++11 but I wanted to also use it with more recent c++ standards. However, I got the following error when compiling the libsimdpp headers for SSE2 using GCC 7.3.1 with the `-std=c++17` option (c++14 works).
```
..../include/simdpp/types/empty_expr.h: In instantiation of ‘simdpp::arch_sse2::mask_int32<N, simdpp::arch_sse2::expr_empty>::operator simdpp::arch_sse2::uint32<N>() const [with unsigned int N = 4]’:
..../include/simdpp/detail/insn/cmp_neq.h:195:52:   required from here
..../include/simdpp/types/empty_expr.h:220:52: error: could not convert ‘((const simdpp::arch_sse2::mask_int32<4, simdpp::arch_sse2::expr_empty>*)this)->simdpp::arch_sse2::mask_int32<4, simdpp::arch_sse2::expr_empty>::e’ from ‘const simdpp::arch_sse2::mask_int32<4>’ to ‘simdpp::arch_sse2::uint32<4>’
     SIMDPP_INL operator uint32<N>() const { return e; }
                                                    ^
```

The same line also produces an error on Clang 6.0.0 on c++17.

I managed to find a possible fix for the problem by removing the cast to `uint32x4` of the return value in line cmp_neq.h:195. I believe that cast is not needed anyway and all tests still pass without it.


Best,
Hannes