### PR TITLE
i_load_u_any has to be inlined

### DIFF
--- a/simdpp/detail/insn/load_u.h
+++ b/simdpp/detail/insn/load_u.h
@@ -325,7 +325,7 @@ void i_load_u(V& a, const char* p)
     }
 }
 
-template<class V>
+template<class V> SIMDPP_INL
 V i_load_u_any(const char* p)
 {
     typename detail::remove_sign<V>::type r;


### PR DESCRIPTION
Without inlining, it causes a crash on MinGW when returned value is not properly aligned. The full bug report is here:
https://osdn.net/projects/mingw/ticket/39565