### PR TITLE
fix: simdpp/types/empty_expr.h: c++17 compilation fix

### DIFF
--- a/simdpp/types/empty_expr.h
+++ b/simdpp/types/empty_expr.h
@@ -217,7 +217,7 @@ public:
     SIMDPP_INL mask_int32(const mask_int32<N>& a) : e(a) {}
 
     SIMDPP_INL operator mask_int32<N>() const { return e; }
-    SIMDPP_INL operator uint32<N>() const { return e; }
+    SIMDPP_INL operator uint32<N>() const { return bit_cast<uint32<N>>(e); }
     SIMDPP_INL mask_int32<N> eval() const { return e; }
 };
 


### PR DESCRIPTION
Compiling with `gcc -std=c++17 ` gave an error message.