### PR TITLE
Add bitonic sort algorithm

### DIFF
--- a/simdpp/algorithm/bitonic_sort.h
+++ b/simdpp/algorithm/bitonic_sort.h
@@ -1,0 +1,231 @@
+/*  Copyright (C) 2024  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_SIMDPP_ALGORITHM_BITONIC_SORT
+#define LIBSIMDPP_SIMDPP_ALGORITHM_BITONIC_SORT
+
+#include <simdpp/simd.h>
+
+namespace simdpp {
+namespace SIMDPP_ARCH_NAMESPACE {
+
+namespace detail {
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_4lane_2el_asc_2el_dec(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T swapped = permute4<1, 0, 3, 2>(aw);
+
+    T res_min = min(aw, swapped);
+    T res_max = max(aw, swapped);
+
+    return shuffle4x2<1, 4, 7, 2>(res_min, res_max);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_4lane_2el_asc_2el_asc(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T swapped = permute4<1, 0, 3, 2>(aw);
+
+    T res_min = min(aw, swapped);
+    T res_max = max(aw, swapped);
+
+    return shuffle4x2<1, 4, 2, 7>(res_min, res_max);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_4lane_2el_dec_2el_dec(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T swapped = permute4<1, 0, 3, 2>(aw);
+
+    T res_max = max(aw, swapped);
+    T res_min = min(aw, swapped);
+
+    return shuffle4x2<1, 4, 2, 7>(res_max, res_min);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_4lane_corresponding_2el_asc(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+    T swapped = permute4<2, 3, 0, 1>(aw);
+
+    T res_min = min(aw, swapped);
+    T res_max = max(aw, swapped);
+
+    return shuffle4x2<0, 1, 4, 5>(res_min, res_max);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_4lane_corresponding_2el_dec(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+    T swapped = permute4<2, 3, 0, 1>(aw);
+
+    T res_max = max(aw, swapped);
+    T res_min = min(aw, swapped);
+
+    return shuffle4x2<0, 1, 4, 5>(res_max, res_min);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_8lane_corresponding_4el_asc(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+    T lo = shuffle1_128<0, 0>(aw, aw);
+    T hi = shuffle1_128<1, 1>(aw, aw);
+
+    T res_min = min(lo, hi);
+    T res_max = max(lo, hi);
+
+    return shuffle1_128<0, 0>(res_min, res_max);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_8lane_corresponding_4el_dec(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+    T lo = shuffle1_128<0, 0>(aw, aw);
+    T hi = shuffle1_128<1, 1>(aw, aw);
+
+    T res_max = max(lo, hi);
+    T res_min = min(lo, hi);
+
+    return shuffle1_128<0, 0>(res_max, res_min);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T reverse_8lane_top4(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T reversed = permute4<3, 2, 1, 0>(aw);
+
+    return shuffle1_128<0, 1>(aw, reversed);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T reverse_8lane_bottom4(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T reversed = permute4<3, 2, 1, 0>(aw);
+
+    return shuffle1_128<0, 1>(reversed, aw);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_8lane_4el_asc_4el_dec(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T step1_res = sort_4lane_2el_asc_2el_dec(aw);
+    T step2_res = sort_4lane_corresponding_2el_asc(step1_res);
+    T step3_res = sort_4lane_2el_asc_2el_asc(step2_res);
+
+    return reverse_8lane_top4(step3_res);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T sort_8lane_4el_dec_4el_asc(const any_vec32<N,T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T step1_res = sort_4lane_2el_asc_2el_dec(aw);
+    T step2_res = sort_4lane_corresponding_2el_asc(step1_res);
+    T step3_res = sort_4lane_2el_asc_2el_asc(step2_res);
+
+    return reverse_8lane_bottom4(step3_res);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T bitonic_sort_8lane_finalize_asc(const any_vec32<N, T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T step1_res = sort_8lane_corresponding_4el_asc(aw);
+    T step2_res = sort_4lane_corresponding_2el_asc(step1_res);
+    return sort_4lane_2el_asc_2el_asc(step2_res);
+}
+
+template<unsigned N, class T>
+SIMDPP_INL T bitonic_sort_8lane_finalize_dec(const any_vec32<N, T>& a)
+{
+    auto& aw = a.wrapped();
+
+    T step1_res = sort_8lane_corresponding_4el_dec(aw);
+    T step2_res = sort_4lane_corresponding_2el_dec(step1_res);
+    return sort_4lane_2el_dec_2el_dec(step2_res);
+}
+
+} // namespace detail
+
+/** Sorts data in the given SIMD registers in increasing order. Sort is not stable.
+*/
+template<class T>
+void bitonic_sort_asc(any_vec32<8,T>& a0)
+{
+    auto r = detail::sort_8lane_4el_asc_4el_dec(a0.wrapped());
+    a0.wrapped() = detail::bitonic_sort_8lane_finalize_asc(r);
+}
+
+template<class T>
+void bitonic_sort_dec(any_vec32<8,T>& a0)
+{
+    auto r = detail::sort_8lane_4el_dec_4el_asc(a0.wrapped());
+    a0.wrapped() = detail::bitonic_sort_8lane_finalize_dec(r);
+}
+
+
+template<class T>
+void bitonic_sort_asc(any_vec32<8,T>& a0, any_vec32<8,T>& a1)
+{
+    auto r0 = a0.wrapped();
+    auto r1 = a1.wrapped();
+    r0 = detail::sort_8lane_4el_asc_4el_dec(r0);
+    r0 = detail::bitonic_sort_8lane_finalize_asc(r0);
+    r1 = detail::sort_8lane_4el_asc_4el_dec(r1);
+    r1 = detail::bitonic_sort_8lane_finalize_dec(r1);
+
+    T res_max = max(r0, r1);
+    T res_min = min(r0, r1);
+
+    r0 = detail::bitonic_sort_8lane_finalize_asc(res_min);
+    r1 = detail::bitonic_sort_8lane_finalize_asc(res_max);
+    a0.wrapped() = r0;
+    a1.wrapped() = r1;
+}
+
+template<class T>
+void bitonic_sort_dec(any_vec32<8,T>& a0, any_vec32<8,T>& a1)
+{
+    auto r0 = a0.wrapped();
+    auto r1 = a1.wrapped();
+    r0 = detail::sort_8lane_4el_dec_4el_asc(r0);
+    r0 = detail::bitonic_sort_8lane_finalize_dec(r0);
+    r1 = detail::sort_8lane_4el_dec_4el_asc(r1);
+    r1 = detail::bitonic_sort_8lane_finalize_asc(r1);
+
+    T res_max = max(r0, r1);
+    T res_min = min(r0, r1);
+
+    r0 = detail::bitonic_sort_8lane_finalize_dec(res_max);
+    r1 = detail::bitonic_sort_8lane_finalize_dec(res_min);
+    a0.wrapped() = r0;
+    a1.wrapped() = r1;
+}
+
+} // namespace simdpp
+} // namespace SIMDPP_ARCH_NAMESPACE
+
+#endif // LIBSIMDPP_SIMDPP_ALGORITHM_BITONIC_SORT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,7 @@ set(TEST_INSN_ARCH_SOURCES
     insn/test_utils.cc
     insn/tests.cc
     insn/transpose.cc
+    algorithm/bitonic_sort.cc
 )
 
 set(TEST_INSN_ARCH_GEN_SOURCES "")

--- a/test/algorithm/bitonic_sort.cc
+++ b/test/algorithm/bitonic_sort.cc
@@ -1,0 +1,109 @@
+/*  Copyright (C) 2024  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include <simdpp/simd.h>
+#include <simdpp/algorithm/bitonic_sort.h>
+#include "../insn/tests.h"
+#include "../utils/test_helpers.h"
+#include <algorithm>
+#include <array>
+#include <random>
+
+namespace SIMDPP_ARCH_NAMESPACE {
+
+template<class V, unsigned N, bool Ascending>
+struct TestDataPreparer
+{
+    using E = typename V::element_type;
+
+    TestDataPreparer()
+    {
+        for (std::uint32_t i = 0; i < data.size(); ++i)
+        {
+            data[i] = static_cast<E>(i);
+        }
+        expected_data = data;
+        std::sort(expected_data.begin(), expected_data.end(), [](auto l, auto r)
+        {
+            if (Ascending) {
+                return l < r;
+            } else {
+                return l > r;
+            };
+        });
+    }
+
+    void next()
+    {
+        std::shuffle(data.begin(), data.end(), rng);
+    }
+
+    std::minstd_rand rng = std::minstd_rand{123};
+    std::array<E, N> data;
+    std::array<E, N> expected_data;
+};
+
+template<class V, bool Ascending>
+void test_bitonic_sort_impl1_v(TestReporter& tr)
+{
+    TestDataPreparer<V, 8, Ascending> data_preparer;
+
+    for (std::uint32_t i = 0; i < 1000; ++i)
+    {
+        data_preparer.next();
+
+        V sorted = simdpp::load_u(&data_preparer.data[0]);
+        if (Ascending) {
+            simdpp::bitonic_sort_asc(sorted);
+        } else {
+            simdpp::bitonic_sort_dec(sorted);
+        }
+        V expected = simdpp::load_u(&data_preparer.expected_data[0]);
+        TEST_EQUAL(tr, sorted, expected);
+    }
+}
+
+template<class V, bool Ascending>
+void test_bitonic_sort_impl2_v(TestReporter& tr)
+{
+    TestDataPreparer<V, 16, Ascending> data_preparer;
+
+    for (std::uint32_t i = 0; i < 1000; ++i)
+    {
+        data_preparer.next();
+
+        V sorted1 = simdpp::load_u(&data_preparer.data[0]);
+        V sorted2 = simdpp::load_u(&data_preparer.data[8]);
+        if (Ascending) {
+            simdpp::bitonic_sort_asc(sorted1, sorted2);
+        } else {
+            simdpp::bitonic_sort_dec(sorted1, sorted2);
+        }
+        V expected1 = simdpp::load_u(&data_preparer.expected_data[0]);
+        V expected2 = simdpp::load_u(&data_preparer.expected_data[8]);
+        TEST_EQUAL(tr, sorted1, expected1);
+        TEST_EQUAL(tr, sorted2, expected2);
+    }
+}
+
+void test_algorithm_bitonic_sort(TestReporter& tr)
+{
+    test_bitonic_sort_impl1_v<simdpp::float32<8>, true>(tr);
+    test_bitonic_sort_impl1_v<simdpp::uint32<8>, true>(tr);
+    test_bitonic_sort_impl1_v<simdpp::int32<8>, true>(tr);
+    test_bitonic_sort_impl1_v<simdpp::float32<8>, false>(tr);
+    test_bitonic_sort_impl1_v<simdpp::uint32<8>, false>(tr);
+    test_bitonic_sort_impl1_v<simdpp::int32<8>, false>(tr);
+    test_bitonic_sort_impl2_v<simdpp::float32<8>, true>(tr);
+    test_bitonic_sort_impl2_v<simdpp::uint32<8>, true>(tr);
+    test_bitonic_sort_impl2_v<simdpp::int32<8>, true>(tr);
+    test_bitonic_sort_impl2_v<simdpp::float32<8>, false>(tr);
+    test_bitonic_sort_impl2_v<simdpp::uint32<8>, false>(tr);
+    test_bitonic_sort_impl2_v<simdpp::int32<8>, false>(tr);
+}
+
+} // namespace SIMDPP_ARCH_NAMESPACE

--- a/test/expr/tests.h
+++ b/test/expr/tests.h
@@ -15,5 +15,6 @@ void test_expr_bitwise(TestReporter& ts);
 void test_expr_math_float(TestReporter& ts);
 void test_expr_math_int(TestReporter& ts);
 void test_expr_compare(TestReporter& tr);
+void test_algorithm_bitonic_sort(TestReporter& tr);
 
 #endif

--- a/test/insn/tests.cc
+++ b/test/insn/tests.cc
@@ -71,6 +71,8 @@ void main_test_function(TestResults& res, TestReporter& tr, const TestOptions& o
     test_transpose(res);
 
     test_for_each(res, tr);
+
+    test_algorithm_bitonic_sort(tr);
 }
 
 } // namespace SIMDPP_ARCH_NAMESPACE

--- a/test/insn/tests.h
+++ b/test/insn/tests.h
@@ -36,6 +36,7 @@ void test_permute_generic(TestResults& res);
 void test_shuffle_transpose(TestResults& res);
 void test_test_utils(TestResults& res);
 void test_transpose(TestResults& res);
+void test_algorithm_bitonic_sort(TestReporter& tr);
 
 } // namespace SIMDPP_ARCH_NAMESPACE
 


### PR DESCRIPTION
Currently only low-level register-based interface is exposed. Even the 16 lane sort is small enough and uses few enough registers on e.g. AVX2 that it makes sense to inline it and pass both input and gather output via SIMD registers without going to memory.

A higher-level, memory based interface can be exposed in the future.