### PR TITLE
insn: Work around in GCC regression when generating comparisons on ARM

### DIFF
--- a/simdpp/detail/insn/cmp_ge.h
+++ b/simdpp/detail/insn/cmp_ge.h
@@ -331,7 +331,18 @@ mask_float32<4> i_cmp_ge(const float32<4>& a, const float32<4>& b)
 #elif SIMDPP_USE_SSE2
     return _mm_cmpge_ps(a.native(), b.native());
 #elif SIMDPP_USE_NEON
+#if SIMDPP_32_BITS && defined(__GNUC__) && (__GNUC__ >= 11) && !defined(__clang__)
+    // BUG: Starting GCC 11 and up until at least GCC 14 floating-point comparison intrinics get
+    // broken down to scalar code on armv7. https://godbolt.org/z/MbnMhzrTT
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115451
+    float32x4_t va = a.native();
+    float32x4_t vb = b.native();
+    float32x4_t vr;
+    asm("vcge.f32 %q0, %q1, %q2 " : "=w"(vr) : "w"(va) , "w"(vb));
+    return vr;
+#else
     return vreinterpretq_f32_u32(vcgeq_f32(a.native(), b.native()));
+#endif
 #elif SIMDPP_USE_ALTIVEC
     return vec_cmpge(a.native(), b.native());
 #elif SIMDPP_USE_MSA

--- a/simdpp/detail/insn/cmp_gt.h
+++ b/simdpp/detail/insn/cmp_gt.h
@@ -394,7 +394,18 @@ mask_float32x4 i_cmp_gt(const float32x4& a, const float32x4& b)
 #elif SIMDPP_USE_SSE2
     return _mm_cmpgt_ps(a.native(), b.native());
 #elif SIMDPP_USE_NEON
+#if SIMDPP_32_BITS && defined(__GNUC__) && (__GNUC__ >= 11) && !defined(__clang__)
+    // BUG: Starting GCC 11 and up until at least GCC 14 floating-point comparison intrinics get
+    // broken down to scalar code on armv7. https://godbolt.org/z/MbnMhzrTT
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115451
+    float32x4_t va = a.native();
+    float32x4_t vb = b.native();
+    float32x4_t vr;
+    asm("vcgt.f32 %q0, %q1, %q2 " : "=w"(vr) : "w"(va) , "w"(vb));
+    return vr;
+#else
     return vreinterpretq_f32_u32(vcgtq_f32(a.native(), b.native()));
+#endif
 #elif SIMDPP_USE_ALTIVEC
     return vec_cmpgt(a.native(), b.native());
 #elif SIMDPP_USE_MSA

--- a/simdpp/detail/insn/cmp_lt.h
+++ b/simdpp/detail/insn/cmp_lt.h
@@ -390,7 +390,18 @@ mask_float32x4 i_cmp_lt(const float32x4& a, const float32x4& b)
 #elif SIMDPP_USE_SSE2
     return _mm_cmplt_ps(a.native(), b.native());
 #elif SIMDPP_USE_NEON
+#if SIMDPP_32_BITS && defined(__GNUC__) && (__GNUC__ >= 11) && !defined(__clang__)
+    // BUG: Starting GCC 11 and up until at least GCC 14 floating-point comparison intrinics get
+    // broken down to scalar code on armv7. https://godbolt.org/z/MbnMhzrTT
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115451
+    float32x4_t va = a.native();
+    float32x4_t vb = b.native();
+    float32x4_t vr;
+    asm("vcgt.f32 %q0, %q1, %q2 " : "=w"(vr) : "w"(vb) , "w"(va));
+    return vr;
+#else
     return vreinterpretq_f32_u32(vcltq_f32(a.native(), b.native()));
+#endif
 #elif SIMDPP_USE_ALTIVEC
     return vec_cmplt(a.native(), b.native());
 #elif SIMDPP_USE_MSA


### PR DESCRIPTION
Starting with GCC 11 and as of GCC 14.1, the following code:

```
uint32x4_t test(float32x4_t a, float32x4_t b)
{
    return vcgtq_f32(a, b);
}
```

Generates the following assembly on armv7:

```
test(__simd128_float32_t, __simd128_float32_t):
        vmov.32 r3, d0[0]
        sub     sp, sp, #16
        vmov    s8, r3
        vmov.32 r3, d0[1]
        vmov    s10, r3
        vmov.32 r3, d1[0]
        vmov    s12, r3
        vmov.32 r3, d1[1]
        vmov    s14, r3
        vmov.32 r3, d2[0]
        vmov    s9, r3
        vmov.32 r3, d2[1]
        vcmpe.f32       s8, s9
        vmov    s11, r3
        vmov.32 r3, d3[0]
        vmrs    APSR_nzcv, FPSCR
        vcmpe.f32       s10, s11
        vmov    s13, r3
        vmov.32 r3, d3[1]
        vmov    s15, r3
        ite     gt
        movgt   r3, #-1
        movle   r3, #0
        vmrs    APSR_nzcv, FPSCR
        vcmpe.f32       s12, s13
        str     r3, [sp]
        ite     gt
        movgt   r3, #-1
        movle   r3, #0
        vmrs    APSR_nzcv, FPSCR
        vcmpe.f32       s14, s15
        str     r3, [sp, #4]
        ite     gt
        movgt   r3, #-1
        movle   r3, #0
        vmrs    APSR_nzcv, FPSCR
        str     r3, [sp, #8]
        ite     gt
        movgt   r3, #-1
        movle   r3, #0
        str     r3, [sp, #12]
        vld1.64 {d0-d1}, [sp:64]
        add     sp, sp, #16
        bx      lr
```