### PR TITLE
#188 fix simdpp::extract(float32<4>) for MSVC x86_64 SSE2/3/4 build

### DIFF
--- a/simdpp/detail/insn/extract.h
+++ b/simdpp/detail/insn/extract.h
@@ -351,6 +351,7 @@ float i_extract(const float32<4>& a)
     return a.el(id);
 #elif SIMDPP_USE_SSE2
     switch (id) {
+    default:
     case 0: return _mm_cvtss_f32(a.native());
 #if SIMDPP_USE_SSE3
     case 1: return _mm_cvtss_f32(_mm_movehdup_ps(a.native()));


### PR DESCRIPTION
 was failing with
```
Error C4715 'simdpp::arch_sse4p1::detail::insn::i_extract<0>': not all control paths return a value
```