### PR TITLE
Exclude math_accuracy tests from ALL_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ simdpp_get_runnable_archs(NATIVE_ARCHS)
 set(SIMDPP_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include/${PKG_NAME}-${SIMDPP_API_VERSION}")
 set(SIMDPP_DOCDIR "${CMAKE_INSTALL_PREFIX}/share/doc/${PKG_NAME}")
 set(SIMDPP_PKGCONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+option(LIBSIMDPP_ENABLE_TESTS "Enable libsimdpp tests" ON)
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/libsimdpp.pc.in"
@@ -58,4 +59,7 @@ install(FILES
 enable_testing()
 
 add_subdirectory(simdpp)
+
+if (LIBSIMDPP_ENABLE_TESTS)
 add_subdirectory(test)
+endif()

--- a/simdpp/detail/insn/permute4.h
+++ b/simdpp/detail/insn/permute4.h
@@ -101,7 +101,7 @@ uint32x4 i_permute4(const uint32x4& a)
 #elif SIMDPP_USE_SSE2
     return _mm_shuffle_epi32(a.native(), _MM_SHUFFLE(s3, s2, s1, s0));
 #elif SIMDPP_USE_NEON
-#if __GNUC__
+#if __GNUC__ && !__clang__
     return __builtin_shuffle(a.native(), a.native(), (uint32x4_t){s0, s1, s2, s3});
 #else
     return detail::neon_shuffle_int32x4::permute4<s0,s1,s2,s3>(a);
@@ -151,7 +151,7 @@ float32x4 i_permute4(const float32x4& a)
 #elif SIMDPP_USE_SSE2
     return _mm_shuffle_ps(a.native(), a.native(), _MM_SHUFFLE(s3, s2, s1, s0));
 #elif SIMDPP_USE_NEON
-#if __GNUC__ && SIMDPP_USE_NEON_FLT_SP
+#if __GNUC__ && !__clang__ && SIMDPP_USE_NEON_FLT_SP
     return __builtin_shuffle(a.native(), a.native(), (uint32x4_t){s0, s1, s2, s3});
 #else
     return float32x4(detail::neon_shuffle_int32x4::permute4<s0,s1,s2,s3>(int32x4(a)));

--- a/test/math_accuracy/CMakeLists.txt
+++ b/test/math_accuracy/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(SRC ${ARCH_SOURCES})
     simdpp_multiarch(ARCH_GEN_SOURCES ${SRC} ${COMPILABLE_ARCHS})
 endforeach()
 
-add_executable(test_math_accuracy
+add_executable(test_math_accuracy EXCLUDE_FROM_ALL
     ${SOURCES}
     ${ARCH_GEN_SOURCES}
 )


### PR DESCRIPTION
Because this test does not have `EXCLUDE_FROM_ALL`, it will get build in user's main projects when using something generic like `cmake --build .` or `make`.

This PR corrects that by adding the flag - just like in other test executables in `test/CMakeLists.txt`